### PR TITLE
Install Claude Code via setup script

### DIFF
--- a/run_onchange_before_aab_setup.sh.tmpl
+++ b/run_onchange_before_aab_setup.sh.tmpl
@@ -579,6 +579,18 @@ install_cmux() (
 )
 runner install_cmux
 
+# Claude Code (Anthropic's agentic coding CLI)
+install_claude_code() (
+  set -e
+  {{- if (eq .chezmoi.os "darwin") }}
+    brew install --cask claude-code
+  {{- else if (eq .chezmoi.os "linux") }}
+    # No brew on Linux; use the native installer (auto-updates in the background)
+    curl -fsSL https://claude.ai/install.sh | bash
+  {{- end }}
+)
+runner install_claude_code
+
 # bat
 install_bat() (
   set -e


### PR DESCRIPTION
## What

Adds an `install_claude_code` runner to the provisioning script. macOS uses the Homebrew cask (`brew install --cask claude-code`), Linux uses Anthropic's native installer.

## Why

You're leaning into agentic coding with Claude but had nothing set up. Installing Claude Code through chezmoi means every machine you provision gets it reproducibly — the same way `uv`, `fnm`, `bat`, etc. already do — instead of a manual step you'd forget on the next laptop.

The Homebrew cask was chosen to match your existing brew-on-mac pattern. Note: the cask follows the stable channel (~1 week behind) and does not auto-update, so you'll pick up new versions via `brew upgrade`.

https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v)_