### PR TITLE
Manage Claude Code config with chezmoi

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -1,0 +1,26 @@
+# Global instructions for Claude Code
+
+These apply across all repositories on my machines.
+
+## Environment
+
+- Primary OS is the latest macOS (Apple Silicon); I also keep things working on
+  Ubuntu Linux.
+- Shell is `zsh`. Editor is Neovim (LazyVim).
+- Dotfiles are managed with [chezmoi](https://www.chezmoi.io/); files under the
+  source directory are templates, so don't edit the deployed `~/.zshrc` etc.
+  directly — change the chezmoi source.
+
+## Tools to prefer
+
+- Search with `rg` (ripgrep) and `fd`, not `grep -r` / `find`.
+- View files with `bat` when a pager is helpful.
+- Node version is managed by `fnm`; Python by `uv`.
+
+## Working style
+
+- Be concise. Lead with the answer, then the reasoning.
+- Match the surrounding code's style; don't introduce new dependencies or
+  patterns without a reason.
+- Don't add comments that just restate what the code does.
+- Ask before destructive or hard-to-reverse actions.

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "includeCoAuthoredBy": true,
+  "permissions": {
+    "allow": [
+      "Bash(rg:*)",
+      "Bash(fd:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)"
+    ]
+  }
+}


### PR DESCRIPTION
## What

Adds `dot_claude/settings.json` and `dot_claude/CLAUDE.md` to the chezmoi source, so `~/.claude/settings.json` and a global `~/.claude/CLAUDE.md` are managed like the rest of your dotfiles.

- `settings.json`: a conservative starter — `includeCoAuthoredBy` and a read-only permissions allowlist (`rg`, `fd`, `git status/diff/log/show`, …) so common safe commands don't prompt.
- `CLAUDE.md`: global standing instructions describing your environment (macOS-primary + Ubuntu compat, zsh, Neovim/LazyVim, chezmoi-managed dotfiles, prefer `rg`/`fd`, `fnm`/`uv`).

## Why

Your whole philosophy is "tell chezmoi about changes so they're reproducible and version-controlled." Claude Code's config (permissions, memory, hooks) is exactly the kind of thing that benefits from being in git with history, and a shared `CLAUDE.md` makes the agent consistent across every repo and machine.

The directory is intentionally `dot_claude/` (not `exact_dot_claude/`), so Claude Code's runtime state (`projects/`, history, `.claude.json`) is left alone. Tweak the allowlist and `CLAUDE.md` to taste — they're starting points.

https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v)_