### PR TITLE
Add Claude to Neovim AI tooling (codecompanion adapter + claudecode.nvim)

### DIFF
--- a/dot_config/nvim/lua/plugins/plugins.lua
+++ b/dot_config/nvim/lua/plugins/plugins.lua
@@ -27,7 +27,7 @@ return {
       return {
         strategies = {
           chat = {
-            adapter = "copilot",
+            adapter = "anthropic",
           },
           tools = {
             opts = {
@@ -42,6 +42,13 @@ return {
           },
         },
         adapters = {
+          anthropic = function()
+            return require("codecompanion.adapters").extend("anthropic", {
+              env = {
+                api_key = "cmd:op read op://Employee/Anthropic/credential --no-newline",
+              },
+            })
+          end,
           gemini = function()
             return require("codecompanion.adapters").extend("gemini", {
               env = {
@@ -168,4 +175,19 @@ return {
 
   -- Stop changing how Markdown looks
   { "MeanderingProgrammer/render-markdown.nvim", enabled = false },
+
+  -- Claude Code <-> Neovim bridge: share selection/diff context with a running
+  -- Claude Code terminal session. Keys are capitalised to coexist with the
+  -- lowercase <leader>a CopilotChat mappings from the ai.copilot extra.
+  {
+    "coder/claudecode.nvim",
+    dependencies = { "folke/snacks.nvim" },
+    config = true,
+    keys = {
+      { "<leader>aC", "<cmd>ClaudeCode<cr>", desc = "Toggle Claude Code" },
+      { "<leader>aF", "<cmd>ClaudeCodeFocus<cr>", desc = "Focus Claude Code" },
+      { "<leader>aA", "<cmd>ClaudeCodeAdd %<cr>", desc = "Add current buffer to Claude Code" },
+      { "<leader>aS", "<cmd>ClaudeCodeSend<cr>", mode = "v", desc = "Send selection to Claude Code" },
+    },
+  },
 }


### PR DESCRIPTION
## What

1. Adds an `anthropic` adapter to `codecompanion.nvim`, pulling the API key from 1Password (`op read op://Employee/Anthropic/credential`) exactly like the existing Gemini adapter, and makes it the **default chat adapter** (was `copilot`).
2. Adds [`coder/claudecode.nvim`](https://github.com/coder/claudecode.nvim) to bridge Neovim with a running Claude Code session — share buffer/selection/diff context between the two. Keymaps live under `<leader>a` with capitalised letters (`aC`/`aF`/`aA`/`aS`) so they coexist with the lowercase CopilotChat mappings from your `ai.copilot` extra.

## Why

You already pay the 1Password-CLI integration cost for Gemini, so extending it to Claude is nearly free and gives you the latest Claude models inside the editor you live in. The bridge means you don't have to choose between "neovim person" and "agentic person" — you can drive a Claude Code session and feed it editor context.

## Heads-up before merging

- Requires a 1Password item at `op://Employee/Anthropic/credential` (mirrors the Gemini path). Adjust the path if yours differs.
- This switches the default codecompanion chat adapter from `copilot` to `anthropic` — revert that one line if you'd rather keep Copilot as default.

https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v)_