### PR TITLE
Update Go install off pinned 1.18

### DIFF
--- a/run_onchange_before_aab_setup.sh.tmpl
+++ b/run_onchange_before_aab_setup.sh.tmpl
@@ -798,11 +798,16 @@ optional_runner install_dbeaver
 install_golang() (
   set -e
   {{- if (eq .chezmoi.os "darwin") }}
-    wget --no-verbose https://go.dev/dl/go1.18.4.darwin-arm64.pkg
-    open -nW go1.18.4.darwin-arm64.pkg
+    # brew keeps Go current; avoids pinning a pkg URL that rots
+    brew install go
   {{- else if (eq .chezmoi.os "linux") }}
-    wget --no-verbose https://go.dev/dl/go1.18.linux-amd64.tar.gz
-    sudo tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
+    # Resolve the latest stable Go release so this doesn't rot to a pinned version
+    GO_VERSION="$(curl -fsSL 'https://go.dev/VERSION?m=text' | head -n1)"
+    wget --no-verbose "https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz"
+    # Remove any previous install before extracting, per the official upgrade docs
+    sudo rm -rf /usr/local/go
+    sudo tar -C /usr/local -xzf "${GO_VERSION}.linux-amd64.tar.gz"
+    rm -f "${GO_VERSION}.linux-amd64.tar.gz"
   {{- end }}
 )
 runner install_golang


### PR DESCRIPTION
## What

`install_golang` pinned **Go 1.18 / 1.18.4** (March 2022) for both platforms. Now:
- **macOS:** `brew install go` (auto-tracks current via `brew upgrade`).
- **Linux:** resolves the latest stable release from `https://go.dev/VERSION?m=text` and installs that tarball, removing any prior `/usr/local/go` first per the official upgrade docs.

## Why

This is the one stale pin that hits your primary OS. Go 1.18 predates generics maturity, the `slices`/`maps` stdlib packages, and ~4 years of toolchain and security fixes (latest is 1.26.x as of June 2026). Pinning a specific URL also means it silently rots — `brew install go` and the dynamic Linux lookup both stay current with no future edits to this file.

https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v)_