### PR TITLE
Bump stale pinned Linux tool versions

### DIFF
--- a/run_onchange_before_aab_setup.sh.tmpl
+++ b/run_onchange_before_aab_setup.sh.tmpl
@@ -515,7 +515,7 @@ fi
 # nvm (node version manager)
 install_nvm() (
   set -e
-  curl -sSo- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+  curl -sSo- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 )
 runner install_nvm
 
@@ -597,8 +597,8 @@ install_bat() (
   {{- if (eq .chezmoi.os "darwin") }}
     brew install bat
   {{- else if (eq .chezmoi.os "linux") }}
-    wget --no-verbose https://github.com/sharkdp/bat/releases/download/v0.18.0/bat_0.18.0_amd64.deb
-    apt_get install ./bat_0.18.0_amd64.deb
+    wget --no-verbose https://github.com/sharkdp/bat/releases/download/v0.25.0/bat_0.25.0_amd64.deb
+    apt_get install ./bat_0.25.0_amd64.deb
   {{- end }}
 )
 runner install_bat
@@ -623,8 +623,8 @@ install_delta() (
   {{- if (eq .chezmoi.os "darwin") }}
     brew install git-delta
   {{- else if (eq .chezmoi.os "linux") }}
-    wget --no-verbose https://github.com/dandavison/delta/releases/download/0.7.1/git-delta_0.7.1_amd64.deb
-    apt_get install ./git-delta_0.7.1_amd64.deb
+    wget --no-verbose https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_amd64.deb
+    apt_get install ./git-delta_0.18.2_amd64.deb
   {{- end }}
 )
 runner install_delta
@@ -974,10 +974,12 @@ install_discord() (
   {{- if .codespaces }}
     # Not on Codespaces
   {{- else if (eq .chezmoi.os "darwin") }}
-    install_dmg https://dl.discordapp.net/apps/osx/0.0.267/Discord.dmg
+    # Use the "latest" download endpoint so this doesn't pin a stale version
+    install_dmg "https://discord.com/api/download?platform=osx"
   {{- else if (eq .chezmoi.os "linux") }}
-    wget --no-verbose https://dl.discordapp.net/apps/linux/0.0.18/discord-0.0.18.deb
-    apt_get install ./discord-0.0.18.deb
+    # Use the "latest" download endpoint so this doesn't pin a stale version
+    wget --no-verbose -O discord.deb "https://discord.com/api/download?platform=linux&format=deb"
+    apt_get install ./discord.deb
   {{- end }}
 )
 optional_runner install_discord


### PR DESCRIPTION
## What

Bumps the years-old version pins in the Linux install fallbacks:
- `bat` 0.18.0 (2021) → 0.25.0
- `git-delta` 0.7.1 (2021) → 0.18.2
- `nvm` 0.39.1 → 0.40.1
- Discord: switched to the `https://discord.com/api/download` "latest" endpoint on both macOS and Linux instead of a pinned build number.

## Why

These are the fallbacks for when you provision an Ubuntu box. delta in particular gained `side-by-side`, `hyperlinks`, and far better navigation since 0.7. They don't affect macOS (brew handles those), which is why this is lower priority than the Go bump — but the moment you spin up Linux you'd otherwise get 4-year-old binaries.

## Scope note

I deliberately left the niche **optional** GUI installers (DBeaver, xournalpp, Roam, MongoDB, Signal-mac dmg) untouched. They self-update after install and don't expose clean "latest" URLs, so exact-version pinning there is fragile — happy to do a follow-up converting them to repo/latest-URL installs if you want.

https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v)_