### PR TITLE
Cache compinit to speed up zsh startup

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -16,8 +16,16 @@ fpath=( "$HOME/.zsh_functions" $fpath )
 fpath=( "/opt/homebrew/share/zsh/site-functions" $fpath )
 {{- end }}
 
-# Enable auto complete
-autoload -Uz compinit && compinit
+# Enable auto complete.
+# Only rebuild the completion dump (and run the slow security audit) once a day;
+# otherwise load the cached dump with `compinit -C`. This keeps shell startup
+# fast since compinit would otherwise rescan all of fpath on every launch.
+autoload -Uz compinit
+if [[ -n ${HOME}/.zcompdump(#qN.mh+24) ]]; then
+  compinit
+else
+  compinit -C
+fi
 
 [ -f $HOME/.zsh_aliases ] && source $HOME/.zsh_aliases
 


### PR DESCRIPTION
## What

Replaces the unconditional `autoload -Uz compinit && compinit` with the standard once-a-day cache check: rebuild `~/.zcompdump` (and run the slow security audit) only if it's older than 24h, otherwise load the cached dump with `compinit -C`.

## Why

`compinit` re-scanned all of `fpath` — including Homebrew's large `site-functions` — and rebuilt the dump on *every* shell start. p10k's instant prompt hides the *perception* of this, but the work still happens and delays when completions/aliases are actually ready. The cached form is the community-standard fix and saves real milliseconds per shell. The `(#qN.mh+24)` glob qualifier needs no `EXTENDED_GLOB` (the explicit `(#q…)` form is always available).

https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v)_