### PR TITLE
Add zsh-autosuggestions

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -124,6 +124,10 @@ add-zsh-hook chpwd _fnm_autoload_hook &&
 # From: https://github.com/junegunn/fzf/issues/164#issuecomment-581837757
 bindkey "ç" fzf-cd-widget
 
+# Fish-style suggestions from history. Source before syntax-highlighting.
+[ -f ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh ] && source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
+
+# NOTE: zsh-syntax-highlighting must be sourced last (after autosuggestions).
 [ -f ~/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ] && source ~/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 
 {{- if (eq .chezmoi.os "darwin") }}

--- a/run_onchange_before_aab_setup.sh.tmpl
+++ b/run_onchange_before_aab_setup.sh.tmpl
@@ -305,6 +305,19 @@ install_zsh_syntax_highlighting() (
 )
 runner install_zsh_syntax_highlighting
 
+# zsh-autosuggestions (Fish-style history suggestions)
+install_zsh_autosuggestions() (
+  set -e
+  if [ -d "$HOME/.zsh/zsh-autosuggestions" ]; then
+    cd "$HOME/.zsh/zsh-autosuggestions"
+    git pull
+    cd -
+  else
+    git clone https://github.com/zsh-users/zsh-autosuggestions.git $HOME/.zsh/zsh-autosuggestions
+  fi
+)
+runner install_zsh_autosuggestions
+
 {{- if .islocalenv }}
 # rust via rustup
 install_rust() (


### PR DESCRIPTION
## What

Installs [`zsh-autosuggestions`](https://github.com/zsh-users/zsh-autosuggestions) the same way you already install `zsh-syntax-highlighting` (git clone into `~/.zsh/`, `git pull` to update), and sources it in `.zshrc` — before syntax-highlighting, as the plugin requires.

## Why

It's the single highest-payoff interactive zsh plugin: Fish-style ghost-text suggestions from your history as you type, accepted with →. It pairs naturally with the syntax highlighter you already run, costs almost nothing to add, and you'd already set up the parallel install pattern for syntax-highlighting.

https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v)_