### PR TITLE
Use native fzf shell integration (fzf --zsh)

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -118,7 +118,11 @@ add-zsh-hook chpwd _fnm_autoload_hook &&
 # END: Auto-switch node versions.
 {{- end }}
 
-[ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+# Ensure fzf is on PATH (Linux git-clone install location; brew handles macOS)
+[ -d "$HOME/.fzf/bin" ] && export PATH="$HOME/.fzf/bin:$PATH"
+# fzf shell integration (keybindings + completion). Built into fzf >= 0.48,
+# so we no longer need the generated ~/.fzf.zsh snapshot.
+command -v fzf >/dev/null 2>&1 && source <(fzf --zsh)
 
 # Get Alt-c working for FZF (NOTE: Can also Type ESC-c)
 # From: https://github.com/junegunn/fzf/issues/164#issuecomment-581837757

--- a/run_onchange_before_aab_setup.sh.tmpl
+++ b/run_onchange_before_aab_setup.sh.tmpl
@@ -202,14 +202,22 @@ runner install_ripgrep
 # fzf
 install_fzf() (
   set -e
-  if [ -d "$HOME/.fzf" ]; then
-    cd "$HOME/.fzf"
-    git pull
-    cd -
-  else
-    git clone --depth 1 https://github.com/junegunn/fzf.git "$HOME/.fzf"
-  fi
-  "$HOME/.fzf/install" --no-bash --no-fish --no-update-rc
+  {{- if (eq .chezmoi.os "darwin") }}
+    # brew puts fzf on PATH and keeps it current; shell integration comes from
+    # `fzf --zsh` (sourced in .zshrc)
+    brew install fzf
+  {{- else }}
+    if [ -d "$HOME/.fzf" ]; then
+      cd "$HOME/.fzf"
+      git pull
+      cd -
+    else
+      git clone --depth 1 https://github.com/junegunn/fzf.git "$HOME/.fzf"
+    fi
+    # --bin only fetches the fzf binary into ~/.fzf/bin; no rc-file edits needed
+    # since .zshrc adds it to PATH and sources `fzf --zsh`
+    "$HOME/.fzf/install" --bin
+  {{- end }}
 )
 runner install_fzf
 


### PR DESCRIPTION
## What

- `.zshrc`: replaces `[ -f ~/.fzf.zsh ] && source ~/.fzf.zsh` with `source <(fzf --zsh)` (fzf ≥ 0.48's built-in integration), plus a PATH line for the Linux clone location.
- Setup script: `brew install fzf` on macOS; on Linux keep the clone but fetch only the binary via `install --bin` (no rc-file edits).

## Why

The old flow cloned fzf and ran its installer to *generate* `~/.fzf.zsh`, a snapshot that drifts from the installed fzf version. `fzf --zsh` emits the keybindings/completions for whatever fzf is actually installed, so it's always in sync, and it drops the generated artifact entirely. `Alt-c`/`Ctrl-r`/`Ctrl-t` and your `ç → fzf-cd-widget` binding keep working.

https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v)_