### PR TITLE
Bump CI actions/checkout v2 → v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
   test-ubuntu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: ./install.sh
       - name: chezmoi data
         run: '"$HOME/.local/bin/chezmoi" data'
@@ -19,14 +19,14 @@ jobs:
       env:
         CODESPACES: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: ./install.sh
       - name: chezmoi data
         run: '"$HOME/.local/bin/chezmoi" data'
   test-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: ./install.sh
       - name: chezmoi data
         run: '"$HOME/.local/bin/chezmoi" data'


### PR DESCRIPTION
## What

Updates all three `actions/checkout@v2` uses in `.github/workflows/ci.yaml` to `@v4`.

## Why

`@v2` runs on the deprecated Node 12 runtime — GitHub already emits deprecation warnings for it and will eventually stop running it. `@v4` is a drop-in upgrade on a supported Node version, keeping your Ubuntu/Codespaces/macOS provisioning CI green.

https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v)_