### PR TITLE
Remove dead ack and ag aliases

### DIFF
--- a/dot_zsh_aliases
+++ b/dot_zsh_aliases
@@ -8,10 +8,8 @@ fi
 alias ls="ls -hAl ${colorflag}"
 alias fif='find ./ -type f -iname'
 alias fid='find ./ -type d -iname'
-alias ack='ack-grep'
 alias tmux="TERM=screen-256color-bce tmux"
 alias recent='for k in `git branch|sed s/^..//`;do echo -e `git log -1 --pretty=format:"%Cgreen%ci %Cblue%cr%Creset" "$k"`\\t"$k";done|sort'
-alias ag='ag --pager="less" --hidden --ignore ".git"'
 alias rgv='rg --no-ignore-vcs --hidden --glob "!**/.git"'
 
 


### PR DESCRIPTION
## What

Removes `alias ack='ack-grep'` and the `ag` (Silver Searcher) alias from `.zsh_aliases`.

## Why

Neither `ack-grep` nor `ag` is installed by your setup any more — you've fully moved to ripgrep (`rg`, `rgv`, and `FZF_DEFAULT_COMMAND='rg ...'`). The dead aliases are cognitive overhead and imply tools that no longer exist; removing them makes `rg` clearly the one search tool.

https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v)_