### PR TITLE
Use eza for the ls alias (with fallback)

### DIFF
--- a/dot_zsh_aliases
+++ b/dot_zsh_aliases
@@ -5,7 +5,12 @@ else # OS X `ls`
 	colorflag="-G"
 fi
 
-alias ls="ls -hAl ${colorflag}"
+# Prefer eza (modern ls: git status column, icons); fall back to system ls
+if command -v eza > /dev/null 2>&1; then
+	alias ls="eza --long --all --group-directories-first --git --icons=auto"
+else
+	alias ls="ls -hAl ${colorflag}"
+fi
 alias fif='find ./ -type f -iname'
 alias fid='find ./ -type d -iname'
 alias tmux="TERM=screen-256color-bce tmux"

--- a/run_onchange_before_aab_setup.sh.tmpl
+++ b/run_onchange_before_aab_setup.sh.tmpl
@@ -624,6 +624,19 @@ install_bat() (
 )
 runner install_bat
 
+# eza (modern ls replacement; the `ls` alias falls back to system ls if absent)
+install_eza() (
+  set -e
+  {{- if (eq .chezmoi.os "darwin") }}
+    brew install eza
+  {{- else if (eq .chezmoi.os "linux") }}
+    # eza is in apt on Ubuntu 24.04+; on older releases this fails harmlessly
+    # and the ls alias falls back to system ls
+    apt_get install eza
+  {{- end }}
+)
+runner install_eza
+
 # fd
 install_fd() (
   set -e


### PR DESCRIPTION
## What

Installs [`eza`](https://github.com/eza-community/eza) and repoints the `ls` alias at it (`--long --all --group-directories-first --git --icons=auto`), keeping your `ls` muscle memory. If `eza` isn't found, the alias falls back to the existing system `ls -hAl`, so nothing breaks.

## Why

Pure quality-of-life: the inline **git status column** in listings is genuinely useful day to day, plus icons and dirs-first sorting. It's easy to revert (one alias) and degrades gracefully — this is the most opinionated/optional of the batch, so no harm if you'd rather close it.

Note: `eza` is in apt on Ubuntu 24.04+; on older Ubuntu the install step fails harmlessly (runner shows ❌ but provisioning continues) and the alias falls back to `ls`.

https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsbZnCTqC72obhV1gPZG9v)_